### PR TITLE
Add caching for thumbnail url

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -134,6 +134,15 @@ final class ImageCacheExtension extends Minz_Extension
         return $content;
     }
 
+    public static function cache_thumbnail(array $thumbnail): array
+    {
+	    if (empty($thumbnail['url'])) {
+            return $thumbnail;
+        }
+        self::send_proactive_cache_request($thumbnail['url']);
+
+        return $thumbnail;
+    }
 
     public static function getSrcSetUris(array $matches): string {
         return str_replace($matches[1], self::getCacheImageUri($matches[1]), $matches[0]);
@@ -173,10 +182,24 @@ final class ImageCacheExtension extends Minz_Extension
         return $doc->saveHTML();
     }
 
+	public static function swapThumbnail(array $thumbnail): array
+    {
+	    if (empty($thumbnail['url'])) {
+            return $thumbnail;
+        }
+        
+        $thumbnail['url'] = self::getCacheImageUri($thumbnail['url']);
+        return $thumbnail;
+    }
+
     public static function content_modification_hook($entry)
     {
         $entry->_content(
             self::swapUris($entry->content())
+        );
+	    $entry->_attribute(
+            'thumbnail',
+            self::swapThumbnail($entry->attributeArray('thumbnail') ?? [])
         );
 
         return $entry;
@@ -185,6 +208,7 @@ final class ImageCacheExtension extends Minz_Extension
     public static function image_upload_hook($entry)
     {
         self::cache_images($entry->content());
+        self::cache_thumbnail($entry->attributeArray('thumbnail') ?? []);
         return $entry;
     }
 }


### PR DESCRIPTION
Currently, caching is only applied to the content of an entry. If you check the img src in the thumbnail column, you'll find that they still use the original url instead of the specified piccache endpoint.

This PR implements caching (incl. proactive caching) for thumbnails.

#### Prerequisite: Enabling the thumbnail column

The setting can be found within Display configuration:
<img width="207" height="54" alt="Thumbnail settings" src="https://github.com/user-attachments/assets/f801b0e7-7d64-48f0-b7e5-8caff50b75b0" />

A new thumbnail column appears:
<img width="527" height="174" alt="List of entries with a new thumbnail column" src="https://github.com/user-attachments/assets/63a39ab2-7746-4d39-8ced-664ee3d51877" />
