### PR TITLE
Add thumbnail support for entries without explicitly specified thumbnails

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -199,7 +199,7 @@ final class ImageCacheExtension extends Minz_Extension
         );
 	    $entry->_attribute(
             'thumbnail',
-            self::swapThumbnail($entry->attributeArray('thumbnail') ?? [])
+            self::swapThumbnail($entry->thumbnail() ?? [])
         );
 
         return $entry;


### PR DESCRIPTION
This PR further improves upon the thumbnail caching introduced in #16. Until now, only the entries that have an explicitly set thumbnail url use the custom caching url for displaying, but not those where the thumbnail is taken from the entry content instead. To fix this, we can simply call the FreshRSS thumbnail resolving function early.
There are no changes to the preemptive caching because no additional requests need to be made for thumbnails taken from the entry content.