### PR TITLE
Avoid caching the cache (for not explicitly specified thumbnails)

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -85,9 +85,14 @@ final class ImageCacheExtension extends Minz_Extension
 	    return strcmp(substr(strtolower($url), 0, 5), "data:") != 0;
     }
 
+    public static function is_cache_url(string $url): bool
+    {
+        return str_starts_with($url, FreshRSS_Context::userConf()->image_cache_url);
+    }
+
     public static function send_proactive_cache_request(string $url): bool
     {
-        if (FreshRSS_Context::userConf()->image_cache_post_enabled && self::is_remote_url($url)) {
+        if (FreshRSS_Context::userConf()->image_cache_post_enabled && self::is_remote_url($url) && !self::is_cache_url($url)) {
             $post_url = FreshRSS_Context::userConf()->image_cache_post_url;
             return self::curlPostRequest($post_url, array("access_token" => FreshRSS_Context::userConf()->image_cache_access_token, "url" => $url));
         }
@@ -96,7 +101,7 @@ final class ImageCacheExtension extends Minz_Extension
 
     public static function getCacheImageUri(string $url): string
     {
-        if (!self::is_remote_url($url)) {
+        if (!self::is_remote_url($url) || self::is_cache_url($url)) {
             return $url;
         }
         $url = rawurlencode($url);


### PR DESCRIPTION
This PR aims to fix an oversight with thumbnail caching I introduced in #17 which caused the thumbnail to appear twice. Under some circumstances (but not in all cases), FreshRSS would feed the already cached url back through the extension before displaying. This caused the cache url to be cachified once more, so the duplicate enclosure detection of FreshRSS did not work, hence appearing twice. Also, yes, we asked our cache endpoint to serve itself, which I find somewhat amusing and which piccache.php will do no questions asked :P but it's probably a good thing that this issue is now fixed.